### PR TITLE
use icanhazip.com and switch to new authorization scheme

### DIFF
--- a/cloudflare_ddns.sh.template
+++ b/cloudflare_ddns.sh.template
@@ -14,7 +14,6 @@ email='your_email_address'
 
 #you can find your api key here: https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-
 api_key='your_api_key'
-
 public_ip=$(curl -s https://icanhazip.com)
 
 current_ip=$(dig +short $domain)
@@ -23,12 +22,6 @@ zone_id="$(curl -sX GET "$api_url/zones" \
                 -H "Authorization: Bearer $api_key" \
                 -H "Content-Type: application/json" \
                 | jq -r '.result[] | select (.name | contains("'$zone'"))' | jq -r .id)"
-echo $zone_id
-#account_id="$(curl -sX GET "$api_url/zones" \
-#                   -H "X-Auth-Email: $email" \
-#                   -H "X-Auth-Key: $api_key" \
-#                   -H "Content-Type: application/json" \
-#                   | jq -r '.result[] | select (.name | contains("'$zone'"))' | jq -r .account.id)"
 
 record_id="$(curl -sX GET "$api_url/zones/$zone_id/dns_records?type=A&name=$domain&direction=desc&match=all" \
                   -H "Authorization: Bearer $api_key" \

--- a/cloudflare_ddns.sh.template
+++ b/cloudflare_ddns.sh.template
@@ -15,16 +15,15 @@ email='your_email_address'
 #you can find your api key here: https://support.cloudflare.com/hc/en-us/articles/200167836-Where-do-I-find-my-Cloudflare-API-key-
 api_key='your_api_key'
 
-public_ip=$(curl -s ifconfig.io)
+public_ip=$(curl -s https://icanhazip.com)
 
 current_ip=$(dig +short $domain)
 
 zone_id="$(curl -sX GET "$api_url/zones" \
-                -H "X-Auth-Email: $email" \
-                -H "X-Auth-Key: $api_key" \
+                -H "Authorization: Bearer $api_key" \
                 -H "Content-Type: application/json" \
                 | jq -r '.result[] | select (.name | contains("'$zone'"))' | jq -r .id)"
-
+echo $zone_id
 #account_id="$(curl -sX GET "$api_url/zones" \
 #                   -H "X-Auth-Email: $email" \
 #                   -H "X-Auth-Key: $api_key" \
@@ -32,8 +31,7 @@ zone_id="$(curl -sX GET "$api_url/zones" \
 #                   | jq -r '.result[] | select (.name | contains("'$zone'"))' | jq -r .account.id)"
 
 record_id="$(curl -sX GET "$api_url/zones/$zone_id/dns_records?type=A&name=$domain&direction=desc&match=all" \
-                  -H "X-Auth-Email: $email" \
-                  -H "X-Auth-Key: $api_key" \
+                  -H "Authorization: Bearer $api_key" \
                   -H "Content-Type: application/json" \
                   | jq -r '.result[] | select (.name | contains("'$domain'"))' | jq -r .id)"
 
@@ -44,8 +42,7 @@ else
     echo $(date)
     echo "Updated IP is"
     curl -sX PUT "$api_url/zones/$zone_id/dns_records/$record_id" \
-         -H "X-Auth-Email: $email" \
-         -H "X-Auth-Key: $api_key" \
+         -H "Authorization: Bearer $api_key" \
          -H "Content-Type: application/json" \
          --data '{"type":"A","name":"'$domain'","content":"'$public_ip'","ttl":1,"proxied":false}' \
          | jq -r .result.content


### PR DESCRIPTION
icanhazip.com is now owned & operated by Cloudflare, so it seems preferable to use it over another 3rd party. Also, the old `X-Auth-Key` scheme seems to be deprecated in favor of `Authorization: Bearer <key>` now